### PR TITLE
Disable icons in menu items

### DIFF
--- a/style/adwaita.h
+++ b/style/adwaita.h
@@ -56,7 +56,7 @@ namespace Adwaita
         const bool SingleClick { true };
         const bool ShowIconsOnPushButtons { true };
         const int ToolButtonStyle { Qt::ToolButtonTextBesideIcon };
-        const bool ShowIconsInMenuItems { true };
+        const bool ShowIconsInMenuItems { false };
     }
 
     enum EnumMnemonicsMode {


### PR DESCRIPTION
Should fix https://github.com/FedoraQt/adwaita-qt/issues/114.

Gnome doesn't seem to use them at all so we will at least be consistent.