### PR TITLE
Fix #141

### DIFF
--- a/style/adwaitastyle.cpp
+++ b/style/adwaitastyle.cpp
@@ -4762,7 +4762,7 @@ bool Style::drawMenuItemControl(const QStyleOption *option, QPainter *painter, c
     }
 
     // We want to always to keep the space for checkbox
-    contentsRect.setLeft(Metrics::CheckBox_Size + Metrics::MenuItem_ItemSpacing);
+    contentsRect.setLeft(rect.left() + Metrics::CheckBox_Size + Metrics::MenuItem_ItemSpacing);
 
     CheckBoxState checkState(menuItemOption->checked ? CheckOn : CheckOff);
     const QColor &outline(palette.foreground().color());


### PR DESCRIPTION
This fixes issue #141 by making the rectangle that the menuitem icon and label go in have correct left coordinates no matter the row of overflow the item is in in a menu or submenu.

After:
![image](https://user-images.githubusercontent.com/11057934/90080329-3bbaea80-dd02-11ea-810a-6e5f30ff8a44.png)
