### PR TITLE
Allow building on Visual Studio

### DIFF
--- a/src/lib/adwaita.h
+++ b/src/lib/adwaita.h
@@ -283,7 +283,7 @@ enum ColorVariant { Unknown, Adwaita, AdwaitaDark, AdwaitaHighcontrast, AdwaitaH
 
 class StyleOptionsPrivate;
 
-class ADWAITAQT_EXPORT StyleOptions
+class ADWAITAQT_MAIN_EXPORT StyleOptions
 {
 public:
     explicit StyleOptions(const QPalette &palette);

--- a/src/lib/adwaitacolors.h
+++ b/src/lib/adwaitacolors.h
@@ -30,7 +30,7 @@
 namespace Adwaita
 {
 
-class ADWAITAQT_EXPORT Colors
+class ADWAITAQT_MAIN_EXPORT Colors
 {
 public:
     // Color adjustments

--- a/src/lib/adwaitaqt_export.h
+++ b/src/lib/adwaitaqt_export.h
@@ -13,6 +13,18 @@
 #    define ADWAITAQT_EXPORT
 #endif
 
+#if defined(_WIN32)
+#  if defined (adwaitaqt6_EXPORTS) || defined (adwaitaqt_EXPORTS)
+#    define ADWAITAQT_MAIN_EXPORT __declspec(dllexport)
+#  else
+#    define ADWAITAQT_MAIN_EXPORT __declspec(dllimport)
+#  endif
+#elif defined(__GNUC__)
+#    define ADWAITAQT_MAIN_EXPORT __attribute__((visibility("default")))
+#else
+#    define ADWAITAQT_MAIN_EXPORT
+#endif
+
 #ifndef ADWAITAQT_NO_EXPORT
 #   define ADWAITAQT_NO_EXPORT __attribute__((visibility("hidden")))
 #endif

--- a/src/lib/adwaitaqt_export.h
+++ b/src/lib/adwaitaqt_export.h
@@ -2,7 +2,11 @@
 #define ADWAITAQT_EXPORT_H
 
 #if defined(_WIN32)
+#  if defined (adwaitaqt6priv_EXPORTS) || defined (adwaitaqtpriv_EXPORTS)
 #    define ADWAITAQT_EXPORT __declspec(dllexport)
+#  else
+#    define ADWAITAQT_EXPORT __declspec(dllimport)
+#  endif
 #elif defined(__GNUC__)
 #    define ADWAITAQT_EXPORT __attribute__((visibility("default")))
 #else

--- a/src/lib/adwaitarenderer.h
+++ b/src/lib/adwaitarenderer.h
@@ -28,7 +28,7 @@
 namespace Adwaita
 {
 
-class ADWAITAQT_EXPORT Renderer
+class ADWAITAQT_MAIN_EXPORT Renderer
 {
 public:
     static void renderDebugFrame(const StyleOptions &options);

--- a/src/lib/animations/adwaitabusyindicatordata.h
+++ b/src/lib/animations/adwaitabusyindicatordata.h
@@ -26,7 +26,7 @@
 
 namespace Adwaita
 {
-class Q_DECL_EXPORT BusyIndicatorData : public QObject
+class ADWAITAQT_EXPORT BusyIndicatorData : public QObject
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
Hi,

This makes a few additions and updates to the macros we use to control export from `libadwaita[6]priv` and `libadwaita[6]`, so that we can build and link and link to them properly on Visual Studio builds.  This has been tested on Visual Studio 2017 x64 + QT 5.15.4 LGPL and Visual Studio 2019 x64 + QT 6.3.1 LGPL.

With blessings, thank you!