### PR TITLE
Fix different text color in unfocused views

### DIFF
--- a/src/lib/adwaitacolors.cpp
+++ b/src/lib/adwaitacolors.cpp
@@ -112,7 +112,8 @@ QColor Colors::lighten(const QColor &color, qreal amount)
 QColor Colors::mix(const QColor &c1, const QColor &c2, qreal bias)
 {
     auto mixQreal = [](qreal a, qreal b, qreal bias) {
-        return a + (b - a) * bias;
+        /* libsass-compilant blending */
+        return bias * b + (1 - bias) * a;
     };
 
     if (bias <= 0.0) {
@@ -125,7 +126,6 @@ QColor Colors::mix(const QColor &c1, const QColor &c2, qreal bias)
 
     if (std::isnan(bias)) {
         return c1;
-
     }
 
     qreal r = mixQreal(c1.redF(), c2.redF(), bias);

--- a/src/style/adwaitastyle.cpp
+++ b/src/style/adwaitastyle.cpp
@@ -393,11 +393,11 @@ void Style::polish(QWidget *widget)
     if (QPointer<QAbstractItemView> view = qobject_cast<QAbstractItemView *>(widget)) {
         QPalette pal = view->palette();
         // TODO keep synced with the standard palette
-        const QColor activeTextColor = _dark ? QColor("#eeeeec") : QColor("#2e3436");
-        const QColor inactiveTextColor = _dark ? Colors::mix(QColor("#eeeeec"), Colors::darken(Colors::desaturate(QColor("#3d3846"), 1.0), 0.04)) :
-                                         Colors::mix(QColor("#2e3436"), QColor("#f6f5f4"));
+        const QString activeTextColor = (_dark ? QColor("#eeeeec") : QColor("#2e3436")).name(QColor::HexArgb);
+        const QString inactiveTextColor = (_dark ? Colors::mix(QColor("#eeeeec"), Colors::darken(Colors::desaturate(QColor("#3d3846"), 1.0), 0.04)) :
+                                         Colors::mix(QColor("#2e3436"), QColor("#f6f5f4"))).name(QColor::HexArgb);
         // No custom text color used, we can do our HACK
-        if (inactiveTextColor == pal.color(QPalette::Inactive, QPalette::Text) && activeTextColor == pal.color(QPalette::Active, QPalette::Text)) {
+        if (inactiveTextColor == pal.color(QPalette::Inactive, QPalette::Text).name(QColor::HexArgb) && activeTextColor == pal.color(QPalette::Active, QPalette::Text).name(QColor::HexArgb)) {
             pal.setColor(QPalette::Inactive, QPalette::Text, pal.color(QPalette::Active, QPalette::Text));
             view->setPalette(pal);
         }


### PR DESCRIPTION
Fixes #126

There is an existing hack for keeping unfocused item views not greyed-out, but it seems outdated and not working.

What has been done:
- Update Colors::mix() to be compatible with libsass's mix()
- Compare HexArgb representation of colors instead of floats