### PR TITLE
Fix QSlider centering inside own container

### DIFF
--- a/src/demo/widgetfactory.ui
+++ b/src/demo/widgetfactory.ui
@@ -454,9 +454,15 @@
     </widget>
    </item>
    <item row="0" column="2" rowspan="8">
-    <layout class="QVBoxLayout" name="verticalLayout_3">
+    <layout class="QVBoxLayout" name="verticalLayout_3" stretch="1,1,1,1,1,1,6">
      <item>
       <widget class="QProgressBar" name="progressbar_horizontal">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="value">
         <number>50</number>
        </property>
@@ -464,6 +470,12 @@
      </item>
      <item>
       <widget class="QProgressBar" name="progressbar_horizontal2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="value">
         <number>50</number>
        </property>
@@ -477,6 +489,12 @@
      </item>
      <item>
       <widget class="QProgressBar" name="progressbar_horizontal3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimum">
         <number>0</number>
        </property>
@@ -496,6 +514,12 @@
      </item>
      <item>
       <widget class="QSlider" name="horizontalslider">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="maximum">
         <number>100</number>
        </property>
@@ -508,6 +532,12 @@
       <widget class="QSlider" name="horizontalslider2">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
        <property name="maximum">
         <number>100</number>
@@ -522,6 +552,12 @@
      </item>
      <item>
       <widget class="QSlider" name="horizontalslider3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="maximum">
         <number>100</number>
        </property>
@@ -549,6 +585,12 @@
       <layout class="QHBoxLayout" name="horizontalLayout_11">
        <item>
         <widget class="QProgressBar" name="progressbar_vertical">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="value">
           <number>50</number>
          </property>
@@ -562,6 +604,12 @@
        </item>
        <item>
         <widget class="QProgressBar" name="progressbar_vertical2">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="value">
           <number>50</number>
          </property>
@@ -575,6 +623,12 @@
        </item>
        <item>
         <widget class="QSlider" name="verticalslider">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="maximum">
           <number>100</number>
          </property>
@@ -593,6 +647,12 @@
         <widget class="QSlider" name="verticalslider2">
          <property name="enabled">
           <bool>false</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <property name="maximum">
           <number>100</number>

--- a/src/style/adwaitastyle.cpp
+++ b/src/style/adwaitastyle.cpp
@@ -2645,27 +2645,38 @@ QRect Style::sliderSubControlRect(const QStyleOptionComplex *option, SubControl 
         return ParentStyleClass::subControlRect(CC_Slider, option, subControl, widget);
     }
 
+    // direction
+    bool horizontal(sliderOption->orientation == Qt::Horizontal);
+
+    // get base class rect
+    QRect rect(ParentStyleClass::subControlRect(CC_Slider, option, subControl, widget));
+
+    // centering
     switch (subControl) {
     case SC_SliderGroove: {
-        // direction
-        bool horizontal(sliderOption->orientation == Qt::Horizontal);
-
-        // get base class rect
-        QRect grooveRect(ParentStyleClass::subControlRect(CC_Slider, option, subControl, widget));
-        grooveRect = insideMargin(grooveRect, pixelMetric(PM_DefaultFrameWidth, option, widget));
-
-        // centering
+        rect = insideMargin(rect, pixelMetric(PM_DefaultFrameWidth, option, widget));
         if (horizontal) {
-            grooveRect = centerRect(grooveRect, grooveRect.width(), Metrics::Slider_GrooveThickness);
+            rect = centerRect(sliderOption->rect, rect.width(), Metrics::Slider_GrooveThickness);
         } else {
-            grooveRect = centerRect(grooveRect, Metrics::Slider_GrooveThickness, grooveRect.height());
+            rect = centerRect(sliderOption->rect, Metrics::Slider_GrooveThickness, rect.height());
         }
-        return grooveRect;
+        break;
+    }
+
+    case SC_SliderHandle: {
+        if (horizontal) {
+            rect.moveTop(sliderOption->rect.center().y() - rect.height() / 2);
+        } else {
+            rect.moveLeft(sliderOption->rect.center().x() - rect.width() / 2);
+        }
+        break;
     }
 
     default:
-        return ParentStyleClass::subControlRect(CC_Slider, option, subControl, widget);
+        break;
     }
+
+    return rect;
 }
 
 //______________________________________________________________


### PR DESCRIPTION
Fix centering algorithm to work the same way as in Fusion style.

Fixes #184

![image](https://user-images.githubusercontent.com/6562863/205015568-9d5a74e5-00da-4907-b407-9ffab9b9afe5.png)
