### PR TITLE
Fix QPalette::PlaceholderText color

### DIFF
--- a/src/lib/adwaitacolors.cpp
+++ b/src/lib/adwaitacolors.cpp
@@ -456,7 +456,7 @@ QPalette Colors::palette(ColorVariant variant)
     palette.setColor(QPalette::All,      QPalette::AlternateBase,   colorsGlobal->adwaitaColor(ColorsPrivate::base_color, variant));
     palette.setColor(QPalette::All,      QPalette::ToolTipBase,     colorsGlobal->adwaitaColor(ColorsPrivate::osd_bg_color, variant));
     palette.setColor(QPalette::All,      QPalette::ToolTipText,     colorsGlobal->adwaitaColor(ColorsPrivate::osd_text_color, variant));
-    palette.setColor(QPalette::All,      QPalette::PlaceholderText, colorsGlobal->adwaitaColor(ColorsPrivate::fg_color, variant));
+    palette.setColor(QPalette::All,      QPalette::PlaceholderText, colorsGlobal->adwaitaColor(ColorsPrivate::insensitive_fg_color, variant));
     palette.setColor(QPalette::All,      QPalette::Text,            colorsGlobal->adwaitaColor(ColorsPrivate::fg_color, variant));
     palette.setColor(QPalette::All,      QPalette::Button,          buttonColor);
     palette.setColor(QPalette::All,      QPalette::ButtonText,      colorsGlobal->adwaitaColor(ColorsPrivate::fg_color, variant));


### PR DESCRIPTION
How placeholder looks in native Adwaita:

![image](https://user-images.githubusercontent.com/6562863/206659863-8f61b04e-6a08-411f-bf9c-b6361bc1d1af.png)

How they look in adwaita-qt:

![image](https://user-images.githubusercontent.com/6562863/206658361-4e6c05a5-99b7-4cd2-8903-e6bdb7aea956.png)

I think it's really confusing. How it does it look after the fix:

![image](https://user-images.githubusercontent.com/6562863/206658829-b2fe9d68-ed18-497b-ac00-7f17e832ee22.png)
