### PR TITLE
Fix table header icon positioning and size

### DIFF
--- a/src/style/adwaitastyle.cpp
+++ b/src/style/adwaitastyle.cpp
@@ -5768,16 +5768,20 @@ bool Style::drawHeaderLabelControl(const QStyleOption *option, QPainter *painter
         QRect rect = header->rect;
         if (!header->icon.isNull()) {
             QPixmap pixmap = header->icon.pixmap(proxy()->pixelMetric(PM_SmallIconSize), (header->state & State_Enabled) ? QIcon::Normal : QIcon::Disabled);
-            int pixw = pixmap.width();
+            int pixw = pixmap.width() / pixmap.devicePixelRatio();
 
-            QRect aligned = alignedRect(header->direction, QFlag(header->iconAlignment), pixmap.size(), rect);
+            QRect aligned = alignedRect(header->direction, QFlag(header->iconAlignment), pixmap.size() / pixmap.devicePixelRatio(), rect);
             QRect inter = aligned.intersected(rect);
-            painter->drawPixmap(inter.x(), inter.y(), pixmap, inter.x() - aligned.x(), inter.y() - aligned.y(), inter.width(), inter.height());
+            painter->drawPixmap(inter.x(), inter.y(), pixmap,
+                                inter.x() - aligned.x(), inter.y() - aligned.y(),
+                                aligned.width() * pixmap.devicePixelRatio(),
+                                aligned.height() * pixmap.devicePixelRatio());
 
+            const int margin = proxy()->pixelMetric(QStyle::PM_HeaderMargin, option, widget);
             if (header->direction == Qt::LeftToRight)
-                rect.setLeft(rect.left() + pixw + 2);
+                rect.setLeft(rect.left() + pixw + margin);
             else
-                rect.setRight(rect.right() - pixw - 2);
+                rect.setRight(rect.right() - pixw - margin);
         }
         QFont fnt = painter->font();
         fnt.setBold(true);


### PR DESCRIPTION
This is basically a port from Fusion style.

Fixes  #187

Problem occurs on specific monitor configuration:
- Wayland
- 2 monitors, one has fractional scaling
- Pixmap in QTableHeaderView drawn DPI-aware

It's difficult to add such case to `demo/showcase` app, since the icon has to be drawn by custom model. However it can be easily checked in KeePassXC app.

Before:
![image](https://user-images.githubusercontent.com/6562863/209955083-9fbf6148-4d5f-4520-99e0-2abf8ea48077.png)

After:
![image](https://user-images.githubusercontent.com/6562863/209955569-277a14c6-db99-4e8a-a48d-6611507093a9.png)
